### PR TITLE
Add support for assume_changed

### DIFF
--- a/src/storage/hashmapped.rs
+++ b/src/storage/hashmapped.rs
@@ -52,10 +52,11 @@ where
 
     fn update_output(&self, cell: Cell, new_value: K::Output) -> bool {
         let mut previous_output = self.cell_to_key.get_mut(&cell).unwrap();
-        let changed = previous_output
-            .1
-            .as_ref()
-            .is_none_or(|value| *value != new_value);
+        let changed = K::ASSUME_CHANGED
+            || previous_output
+                .1
+                .as_ref()
+                .is_none_or(|value| *value != new_value);
         previous_output.1 = Some(new_value);
         changed
     }

--- a/src/storage/indexmapped.rs
+++ b/src/storage/indexmapped.rs
@@ -48,12 +48,13 @@ where
     }
 
     fn update_output(&self, cell: Cell, new_value: K::Output) -> bool {
-        let changed = self
-            .cell_to_key
-            .peek_with(&cell, |_, old_value| {
-                old_value.1.as_ref().is_none_or(|value| *value != new_value)
-            })
-            .unwrap();
+        let changed = K::ASSUME_CHANGED
+            || self
+                .cell_to_key
+                .peek_with(&cell, |_, old_value| {
+                    old_value.1.as_ref().is_none_or(|value| *value != new_value)
+                })
+                .unwrap();
 
         // TreeIndex is read-optimized so this write will be slow
         if changed {

--- a/src/storage/macros.rs
+++ b/src/storage/macros.rs
@@ -28,7 +28,8 @@
 ///     db.get(MyInput) * 2
 /// });
 ///
-/// // It is also possible to signal that the value always changes with the assume_changed keyword:
+/// // It is also possible to signal that the value always changes with the assume_changed keyword.
+/// // Doing so let's us avoid expensive `Eq` checks on large values which are expected to change whenever their inputs do anyway:
 /// define_intermediate!(2, assume_changed More -> i32, MyStorageType, |_, db: &DbHandle<MyStorageType>| {
 ///     db.get(Double) + 1
 /// });

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -64,7 +64,7 @@ pub trait StorageFor<C: OutputType> {
 
     /// `C` has been re-run and has returned the output `new_value`, return `true`
     /// if `new_value` has changed from its previous value, and cache the new value
-    /// if needed.
+    /// if needed. If `C::ASSUME_CHANGED` is true, skip the comparison and assume the value changed.
     fn update_output(&self, cell: Cell, new_value: C::Output) -> bool;
 }
 
@@ -75,6 +75,7 @@ pub trait ComputationId {
 pub trait OutputType {
     type Output;
     const IS_INPUT: bool;
+    const ASSUME_CHANGED: bool;
 }
 
 pub trait Run<Storage>: OutputType {

--- a/src/storage/singleton.rs
+++ b/src/storage/singleton.rs
@@ -53,7 +53,7 @@ where
 
     fn update_output(&self, _: Cell, new_value: K::Output) -> bool {
         let mut guard = self.value.lock().unwrap();
-        let changed = guard.as_ref().is_none_or(|value| *value != new_value);
+        let changed = K::ASSUME_CHANGED || guard.as_ref().is_none_or(|value| *value != new_value);
         *guard = Some(new_value);
         changed
     }

--- a/tests/assume_changed.rs
+++ b/tests/assume_changed.rs
@@ -1,0 +1,68 @@
+// Test file to verify ASSUME_CHANGED const functionality
+use inc_complete::{
+    Db, DbHandle, define_input, define_intermediate, impl_storage, storage::SingletonStorage,
+};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[derive(Debug, Clone)]
+struct CountedValue(i32);
+
+static COMPARISON_COUNTER: AtomicUsize = AtomicUsize::new(0);
+static COMPUTATION_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+impl PartialEq for CountedValue {
+    fn eq(&self, other: &Self) -> bool {
+        COMPARISON_COUNTER.fetch_add(1, Ordering::SeqCst);
+        self.0 == other.0
+    }
+}
+
+impl Eq for CountedValue {}
+
+#[derive(Clone)]
+struct Input;
+
+#[derive(Clone)]
+struct AssumeChangedComputation;
+
+#[derive(Default)]
+struct TestStorage {
+    input: SingletonStorage<Input>,
+    computation: SingletonStorage<AssumeChangedComputation>,
+}
+
+impl_storage!(TestStorage,
+    input: Input,
+    computation: AssumeChangedComputation,
+);
+
+define_input!(0, assume_changed Input -> CountedValue, TestStorage);
+
+// Define computation with ASSUME_CHANGED = true
+// This means the storage will skip equality comparison and always assume the output changed
+define_intermediate!(1, assume_changed AssumeChangedComputation -> CountedValue, TestStorage,  |_, db: &DbHandle<TestStorage>| {
+    COMPUTATION_COUNTER.fetch_add(1, Ordering::SeqCst);
+    CountedValue(db.get(Input).0 + 2)
+});
+
+#[test]
+fn test_assume_changed_skips_comparison() {
+    let mut db = Db::<TestStorage>::new();
+
+    db.update_input(Input, CountedValue(10));
+    let result1 = db.get(AssumeChangedComputation);
+    assert_eq!(result1.0, 12);
+
+    assert_eq!(COMPUTATION_COUNTER.load(Ordering::SeqCst), 1);
+    db.update_input(Input, CountedValue(10));
+    let result2 = db.get(AssumeChangedComputation);
+    assert_eq!(result2.0, 12);
+
+    assert_eq!(COMPUTATION_COUNTER.load(Ordering::SeqCst), 2);
+
+    assert_eq!(
+        COMPARISON_COUNTER.load(Ordering::SeqCst),
+        0,
+        "Comparison was called, but ASSUME_CHANGED = true should skip all comparisons"
+    );
+}


### PR DESCRIPTION
Hi,

This PR adds assume_changed functionality (to skip value comparisons in computation results) and an optional argument to the define_intermediate macro. This macro change is implemented by essentially duplicating most of the macro body but I think this is necessary for backward compatibility and when the derive proc-macros will be in place we can make that argument non optional so the duplication will disappear.